### PR TITLE
install cpan-audit script

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,6 +60,10 @@ my %WriteMakefile = (
 	'BUILD_REQUIRES' => {
 		},
 
+  'EXE_FILES' => [
+    'script/cpan-audit',
+  ],
+
 	'TEST_REQUIRES' => {
 		'Test::More'    => '0.98',
 		'Capture::Tiny' => '0',

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.008001';
 
 requires 'version';
 requires 'CPAN::DistnameInfo';
+requires 'IO::Interactive';
 requires 'Module::CPANfile';
 requires 'Pod::Usage',       '1.69';
 requires 'Module::CoreList', '5.20181020';

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -20,7 +20,7 @@ GetOptions(
     'verbose|v'   => \$opts{verbose},
 ) or die("Error in command line arguments\n");
 
-pod2usage( -input => $FindBin::Bin . "/" . $FindBin::Script ) if $opt_help;
+pod2usage( -input => $FindBin::Bin . "/" . $FindBin::Script ) if $opts{help};
 
 my ($command) = shift @ARGV;
 


### PR DESCRIPTION
The current build doesn't install the `cpan-audit` script. Added the script to the makefile.