### PR TITLE
Minor updates for cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.008001';
+requires 'perl', '5.010001';
 
 requires 'CPAN::DistnameInfo';
 requires 'Encode', '3.12';

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'Encode', '3.12';
 requires 'IO::Interactive';
 requires 'Module::CPANfile';
 requires 'Module::CoreList', '5.20181020';
+requires 'Module::Extract::VERSION';
 requires 'PerlIO::gzip';
 requires 'Pod::Usage',       '1.69';
 requires 'version';


### PR DESCRIPTION
Update the cpanfile: CPAN::Audit requires Perl 5.10.1, but in cpanfile 5.8.1 was listed and Module::Extract::VERSION was missing.