### PR TITLE
IO::Interactive must be a runtime dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -93,7 +93,6 @@ my %WriteMakefile = (
 	'TEST_REQUIRES' => {
 		'Capture::Tiny'   => '0',
 		'HTTP::Tiny'      => '0',
-		'IO::Interactive' => '0',
 		'JSON'            => '0',
 		'Test::More'      => '0.98',
 		},
@@ -103,6 +102,7 @@ my %WriteMakefile = (
 		'Module::CoreList'         => '5.20181020',
 		'Module::CPANfile'         => '0',
 		'Module::Extract::VERSION' => '0',
+		'IO::Interactive'          => '0',
 		'PerlIO::gzip'             => '0',
 		'Pod::Usage'               => '1.69',
 		},


### PR DESCRIPTION
Because `script/cpan-audit` uses IO::Interactive,
it must be a runtime dependency, not a test dependency.


P.S.
https://metacpan.org/release/BDFOY/CPAN-Audit-20220611/source/META.json#L58 specifies
github-issue as a bugtracker, but this repository does not enable github-issue.
You may want to enable it via https://github.com/briandfoy/cpan-audit/settings
