### PR TITLE
Add `--exclude <str>` option, to exclude Advisories/CVEs.  GH-5

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,7 @@ lib/CPAN/Audit/DB.pm.gpg
 lib/CPAN/Audit/Discover.pm
 lib/CPAN/Audit/Discover/Cpanfile.pm
 lib/CPAN/Audit/Discover/CpanfileSnapshot.pm
+lib/CPAN/Audit/Exclude.pm
 lib/CPAN/Audit/FreshnessCheck.pm
 lib/CPAN/Audit/Installed.pm
 lib/CPAN/Audit/Query.pm

--- a/lib/CPAN/Audit/Exclude.pm
+++ b/lib/CPAN/Audit/Exclude.pm
@@ -1,0 +1,27 @@
+package CPAN::Audit::Exclude;
+use strict;
+use warnings;
+
+our $VERSION = "1.001";
+
+sub new {
+    my($class, %params) = @_;
+
+    my $self = bless {}, $class;
+    $self->{exclude} = $params{exclude} // [];
+
+    return $self;
+}
+
+sub is_excluded {
+    my($self, $advisory) = @_;
+
+    return 0 unless (@{$self->{exclude}});
+
+    my %ids = map { ($_ => 1) } grep { defined } ($advisory->{id}, @{$advisory->{cves}});
+
+    return 1 if (grep { $ids{$_} } @{$self->{exclude}});
+    return 0;
+}
+
+1;

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -67,6 +67,7 @@ sub process_options {
 		'quiet|q'     => \$params{quiet},
 		'verbose|v'   => \$params{verbose},
 		'version'     => \$params{version},
+		'exclude=s@'  => \$params{exclude},
 		};
 
 	my $ret = Getopt::Long::GetOptionsFromArray( $args, $options, %$params ) or $class->usage(EXIT_USAGE);
@@ -113,6 +114,7 @@ Options:
     --quiet         be quiet
     --verbose       be verbose
     --version       show the version and exit
+    --exclude <str> exclude/ignore the specified advisory/cve
 
 Examples:
 
@@ -127,6 +129,7 @@ Examples:
 
     cpan-audit installed
     cpan-audit installed local/
+    cpan-audit installed local/ --exclude CVE-2011-4116
 
     cpan-audit show CPANSA-Mojolicious-2018-03
 

--- a/t/cli/module.t
+++ b/t/cli/module.t
@@ -12,6 +12,14 @@ subtest 'command: module' => sub {
     isnt $exit,   0;
 };
 
+subtest 'command: module, with excluded result' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'Catalyst', '--exclude' => 'CPANSA-Catalyst-Runtime-2013-01' );
+
+    unlike $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    is $stderr,   '';
+    is $exit,     0;
+};
+
 subtest 'command: unknown module' => sub {
     my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'Unknown' );
 

--- a/t/cli/release.t
+++ b/t/cli/release.t
@@ -12,6 +12,14 @@ subtest 'command: release' => sub {
     isnt $exit,   0;
 };
 
+subtest 'command: release, with excluded result' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'Catalyst-Runtime', '--exclude' => 'CPANSA-Catalyst-Runtime-2013-01' );
+
+    unlike $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    is $stderr,   '';
+    is $exit,     0;
+};
+
 subtest 'command: unknown release' => sub {
     my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'Unknown' );
 


### PR DESCRIPTION
Allows for Advisories/CVEs to be excluded and ignored from the results.  May be
provided multiple times on the command line when you wish to exclude more than
one Advisory/CVE.