### PR TITLE
add description to NAME

### DIFF
--- a/lib/CPAN/Audit/FreshnessCheck.pm
+++ b/lib/CPAN/Audit/FreshnessCheck.pm
@@ -4,7 +4,7 @@ use v5.10;
 
 =head1 NAME
 
-CPAN::Audit::Freshness
+CPAN::Audit::Freshness - check freshness of CPAN::Audit::DB
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
CPAN-Audit.
We thought you might be interested in it too.

    Description: add description to NAME
     to get a whatis entry in the generated manpage
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-07-19
    Bug: 
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcpan-audit-perl/raw/master/debian/patches/pod.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
