### PR TITLE
New `--exclude-file` option, to exclude/ignore reports from file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension CPAN-Audit
 
+	* Added feature to exclude multiple reports, via file.
+
 20220729.001 2022-07-29T06:29:54Z
 	* Added feature to exclude reports, mostly for those persistent
 	vulnerabilities, such as File::Temp, that won't go away.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options:
     --verbose       be verbose
     --version       show the version and exit
     --exclude <str> exclude/ignore the specified advisory/cve (multiple)
+    --exclude-file <file> read exclude/ignore patterns from file
 
 Examples:
 
@@ -42,6 +43,7 @@ Examples:
     cpan-audit installed local/
     cpan-audit installed local/ --exclude CVE-2011-4116
     cpan-audit installed local/ --exclude CVE-2011-4116 --exclude CVE-2011-123
+    cpan-audit installed local/ --exclude-file ignored-cves.txt
 
     cpan-audit show CPANSA-Mojolicious-2018-03
 

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -16,7 +16,7 @@ our $VERSION = '20220729.001';
 sub new {
     my( $class, %params ) = @_;
 
-    my @allowed_keys = qw(ascii db exclude include_perl interactive no_corelist no_color quiet verbose version);
+    my @allowed_keys = qw(ascii db exclude exclude_file include_perl interactive no_corelist no_color quiet verbose version);
 
     my %args = map { $_, $params{$_} } @allowed_keys;
     my $self = bless \%args, $class;
@@ -24,6 +24,18 @@ sub new {
     if ( !$self->{interactive} ) {
         $self->{ascii}    = 1;
         $self->{no_color} = 1;
+    }
+
+    if ($self->{exclude_file}) {
+        foreach my $file (@{$self->{exclude_file}}) {
+            open my $fh, "<", $file or die "unable to open file [$file]: $!\n";
+            my @excludes =
+                grep { !/^\s*$/ }               # no blank lines
+                map  { s{^\s+|\s+$}{}g; $_ }    # strip leading/trailing whitespace
+                map  { s{#.*}{}; $_ }           # strip comments
+                <$fh>;
+            push @{$self->{exclude}}, @excludes;
+        }
     }
 
     $self->{db}       = CPAN::Audit::DB->db;

--- a/lib/CPAN/Audit/Filter.pm
+++ b/lib/CPAN/Audit/Filter.pm
@@ -32,9 +32,9 @@ CPAN::Audit::Filter - manage the reports / CVEs to ignore
 
 =over 4
 
-=item * new( excludes => ARRAYREF )
+=item * new( exclude => ARRAYREF )
 
-The values in the array ref for C<excludes> are uppercased before
+The values in the array ref for C<exclude> are uppercased before
 they are stored.
 
 =cut

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -68,6 +68,7 @@ sub process_options {
 		'verbose|v'   => \$params{verbose},
 		'version'     => \$params{version},
 		'exclude=s@'  => \$params{exclude},
+		'exclude-file=s@' => \$params{exclude_file},
 		};
 
 	my $ret = Getopt::Long::GetOptionsFromArray( $args, $options, %$params ) or $class->usage(EXIT_USAGE);
@@ -115,6 +116,7 @@ Options:
     --verbose       be verbose
     --version       show the version and exit
     --exclude <str> exclude/ignore the specified advisory/cve (multiple)
+    --exclude-file <file> read exclude/ignore patterns from file
 
 Examples:
 
@@ -131,6 +133,7 @@ Examples:
     cpan-audit installed local/
     cpan-audit installed local/ --exclude CVE-2011-4116
     cpan-audit installed local/ --exclude CVE-2011-4116 --exclude CVE-2011-123
+    cpan-audit installed local/ --exclude-file ignored-cves.txt
 
     cpan-audit show CPANSA-Mojolicious-2018-03
 

--- a/t/cli/module.t
+++ b/t/cli/module.t
@@ -22,6 +22,15 @@ subtest 'command: module, with excluded result' => sub {
     isnt $exit,   0;
 };
 
+subtest 'command: module, with excluded results from file' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'CPAN', '--exclude-file' => 't/data/excludes' );
+
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
 subtest 'command: unknown module' => sub {
     my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'Unknown' );
 

--- a/t/cli/module.t
+++ b/t/cli/module.t
@@ -5,19 +5,21 @@ use Test::More;
 use TestCommand;
 
 subtest 'command: module' => sub {
-    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'Catalyst' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'CPAN' );
 
-    like $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
     is $stderr,   '';
     isnt $exit,   0;
 };
 
 subtest 'command: module, with excluded result' => sub {
-    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'Catalyst', '--exclude' => 'CPANSA-Catalyst-Runtime-2013-01' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'module', 'CPAN', '--exclude' => 'CPANSA-CPAN-2009-01' );
 
-    unlike $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
     is $stderr,   '';
-    is $exit,     0;
+    isnt $exit,   0;
 };
 
 subtest 'command: unknown module' => sub {

--- a/t/cli/release.t
+++ b/t/cli/release.t
@@ -22,6 +22,15 @@ subtest 'command: release, with excluded result' => sub {
     isnt $exit,   0;
 };
 
+subtest 'command: module, with excluded results from file' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'CPAN', '--exclude-file' => 't/data/excludes' );
+
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
 subtest 'command: unknown release' => sub {
     my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'Unknown' );
 

--- a/t/cli/release.t
+++ b/t/cli/release.t
@@ -5,19 +5,21 @@ use Test::More;
 use TestCommand;
 
 subtest 'command: release' => sub {
-    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'Catalyst-Runtime' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'CPAN' );
 
-    like $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
     is $stderr,   '';
     isnt $exit,   0;
 };
 
 subtest 'command: release, with excluded result' => sub {
-    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'Catalyst-Runtime', '--exclude' => 'CPANSA-Catalyst-Runtime-2013-01' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'release', 'CPAN', '--exclude' => 'CPANSA-CPAN-2009-01' );
 
-    unlike $stdout, qr/CPANSA-Catalyst-Runtime-2013-01/;
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
     is $stderr,   '';
-    is $exit,     0;
+    isnt $exit,   0;
 };
 
 subtest 'command: unknown release' => sub {

--- a/t/data/excludes
+++ b/t/data/excludes
@@ -1,0 +1,4 @@
+# Comments are ignored
+
+# as well as blank lines (previous line)
+    CPANSA-CPAN-2009-01   # trailing comments are removed, as is leading/trailing whitespace


### PR DESCRIPTION
While `--exclude` can be provided multiple times on the command line, it would be nice to have the ability to not only exclude multiple reports at once, but to also be able to document _why_ those exclusions are being performed.

Thus, allow for an `--exclude-file` to be provided.  One entry per line, and which can be documented with `#` style comments.