### PR TITLE
add support for output file in JSON format

### DIFF
--- a/META.json
+++ b/META.json
@@ -32,6 +32,7 @@
       "runtime" : {
          "requires" : {
             "CPAN::DistnameInfo" : "0",
+            "JSON" : "0",
             "Module::CPANfile" : "0",
             "Module::CoreList" : "5.20181020",
             "PerlIO::gzip" : "0",
@@ -43,7 +44,7 @@
          "requires" : {
             "Capture::Tiny" : "0",
             "HTTP::Tiny" : "0",
-            "JSON" : "0",
+            "File::Temp" : "0",
             "Test::More" : "0.98"
          }
       }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -92,8 +92,8 @@ my %WriteMakefile = (
 
 	'TEST_REQUIRES' => {
 		'Capture::Tiny'   => '0',
+		'File::Temp'      => '0',
 		'HTTP::Tiny'      => '0',
-		'JSON'            => '0',
 		'Test::More'      => '0.98',
 		},
 
@@ -103,6 +103,7 @@ my %WriteMakefile = (
 		'Module::CPANfile'         => '0',
 		'Module::Extract::VERSION' => '0',
 		'IO::Interactive'          => '0',
+		'JSON'                     => '0',
 		'PerlIO::gzip'             => '0',
 		'Pod::Usage'               => '1.69',
 		},

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
     --version             show the version and exit
     --exclude <str>       exclude/ignore the specified advisory/cve (multiple)
     --exclude-file <file> read exclude/ignore patterns from file
+    --json <file>         save audit results in JSON format in a file
 
 Examples:
 
@@ -44,6 +45,7 @@ Examples:
     cpan-audit installed local/ --exclude CVE-2011-4116
     cpan-audit installed local/ --exclude CVE-2011-4116 --exclude CVE-2011-123
     cpan-audit installed local/ --exclude-file ignored-cves.txt
+    cpan-audit installed --json audit.json
 
     cpan-audit show CPANSA-Mojolicious-2018-03
 

--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@ requires 'perl', '5.010001';
 requires 'CPAN::DistnameInfo';
 requires 'Encode', '3.12';
 requires 'IO::Interactive';
+requires 'JSON';
 requires 'Module::CPANfile';
 requires 'Module::CoreList', '5.20181020';
 requires 'Module::Extract::VERSION';
@@ -12,6 +13,7 @@ requires 'version';
 
 on 'test' => sub {
     requires 'Capture::Tiny', '0.24';
+    requires 'File::Temp';
     requires 'Test::CPAN::Changes';
     requires 'Test::Manifest';
     requires 'Test::More', '0.98';
@@ -19,7 +21,6 @@ on 'test' => sub {
 
 on 'development' => sub {
     requires 'HTTP::Tiny';
-    requires 'JSON';
     requires 'Data::Dumper';
     requires 'File::Basename';
 };

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -61,6 +61,7 @@ sub process_options {
 		'ascii'           => \$params{ascii},
 		'f|fresh'         => \$params{fresh_check},
 		'help|h'          => \$params{help},
+		'json=s'          => \$params{json},
 		'no-color'        => \$params{no_color},
 		'no-corelist'     => \$params{no_corelist},
 		'perl'            => \$params{include_perl},

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -118,6 +118,7 @@ Options:
     --version             show the version and exit
     --exclude <str>       exclude/ignore the specified advisory/cve (multiple)
     --exclude-file <file> read exclude/ignore patterns from file
+    --json <file>         save audit results in JSON format in a file
 
 Examples:
 
@@ -135,6 +136,7 @@ Examples:
     cpan-audit installed local/ --exclude CVE-2011-4116
     cpan-audit installed local/ --exclude CVE-2011-4116 --exclude CVE-2011-123
     cpan-audit installed local/ --exclude-file ignored-cves.txt
+    cpan-audit installed --json audit.json
 
     cpan-audit show CPANSA-Mojolicious-2018-03
 

--- a/t/cli/deps.t
+++ b/t/cli/deps.t
@@ -4,8 +4,10 @@ use lib 't/lib';
 use Test::More;
 use TestCommand;
 
+# exclude CVE-2011-4116 explicitly. It's a known issue in File::Temp wrt symlinks.
+# It should be safe to use the module the way we use it though.
 subtest 'command: deps' => sub {
-    my ( $stdout, $stderr, $exit ) = TestCommand->command('deps');
+    my ( $stdout, $stderr, $exit ) = TestCommand->command('deps', '.', '--exclude', 'CVE-2011-4116');
 
     like $stdout, qr/Discovered \d+ dependencies/;
     is $stderr,   '';

--- a/t/json.t
+++ b/t/json.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+use lib 'lib', 't/lib';
+use Capture::Tiny qw(capture);
+use CPAN::Audit::DB;
+use CPAN::Audit;
+use CPAN::Audit::Discover;
+use File::Temp qw(tempfile);
+use Test::More;
+
+subtest 'json file' => sub {
+    my ($temp_fh, $json_file) = tempfile( 'tempXXXXX', SUFFIX => '.json', UNLINK => 0 );
+    close $temp_fh;
+
+    my $audit = CPAN::Audit->new(
+        json        => $json_file,
+        no_corelist => $json_file,
+    );
+
+    my( $stdout, $stderr, $exit ) = capture {
+        $audit->command(qw[deps t/data/cpanfile/]);
+    };
+
+    like $stdout, qr/Discovered 1 dependencies/;
+    is $stderr,   '';
+    is $exit,     1;
+
+    my $json = do { local ( @ARGV, $/ ) = $json_file; <> };
+    like $json, qr/CPANSATest/;
+
+    unlink $json_file;
+};
+
+done_testing;
+
+{
+    no warnings 'redefine';
+
+    sub CPAN::Audit::DB::db {
+        my $db = {
+            'dists' => {
+                'Catalyst-Runtime' => {
+                    'advisories' => [
+                        {
+                            'affected_versions' => '<5.90020',
+                            'cves' => [],
+                            'description' => 'A sample advisory for a test',
+                            'distribution' => 'Catalyst-Runtime',
+                            'fixed_versions' => '>=5.90020',
+                            'id' => 'CPANSATest-Catalyst-Runtime-2013-01',
+                            'references' => [
+                            ],
+                            'reported' => '2013-01-23'
+                        },
+                    ],
+                    'main_module' => 'Catalyst::Runtime',
+                    'versions' => [
+                        {
+                            'date' => '2021-01-01T18:10:00',
+                            'version' => '5.00',
+                        },
+                        {
+                            'date' => '2022-01-01T18:10:00',
+                            'version' => '5.70',
+                        },
+                    ],
+                },
+            },
+            module2dist => {
+                'Catalyst' => 'Catalyst-Runtime',
+            },
+        };
+
+        return $db;
+    }
+}
+


### PR DESCRIPTION
Having the audit result in JSON format makes it easier to integrate cpan-audit in CI/CD pipelines or importing the results in other apps used to keep track of security issues (e.g. DefectDojo).

It doesn't print the JSON on the STDOUT as other log messages are already printed on STDOUT.