### PR TITLE
Make "dist" subcommand behave as "release"

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -158,7 +158,7 @@ sub command {
 		installed    => 'command_installed',
 		module       => 'command_module',
 		release      => 'command_release',
-		dist         => 'command_dist',
+		dist         => 'command_release',
 		show         => 'command_show',
 	};
 


### PR DESCRIPTION
```
$ cpan-audit dist Catalyst-Runtime 7.0
Can't locate object method "command_dist" via package "CPAN::Audit" at /home/sjn/.plenv/...
```
Since the "dist" subcommand is documented an alias for "release", let's just make that happen.