### PR TITLE
implement modules command to audit a list of modules

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -103,6 +103,26 @@ sub command_show {
 	return;
 }
 
+sub command_modules {
+	my ($self, $dists, @modules) = @_;
+	return "Usage: modules '<module>[,version-range]' '<module>[,version-range]'" unless @modules;
+
+	foreach my $module ( @modules ) {
+		my ($name, $version) = split /;/, $module;
+
+		my $distname = $self->{db}->{module2dist}->{$name};
+
+		if ( !$distname ) {
+			$self->verbose( "Module '$name' is not in database" );
+			next;
+		}
+
+		$dists->{$distname} = $version || '';
+	}
+
+	return;
+}
+
 sub command_deps {
 	my ($self, $dists, $path) = @_;
 	$path = '.' unless defined $path;
@@ -157,6 +177,7 @@ sub command {
 		deps         => 'command_deps',
 		installed    => 'command_installed',
 		module       => 'command_module',
+		modules      => 'command_modules',
 		release      => 'command_release',
 		dist         => 'command_release',
 		show         => 'command_show',

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -110,14 +110,12 @@ sub command_modules {
 	foreach my $module ( @modules ) {
 		my ($name, $version) = split /;/, $module;
 
-		my $distname = $self->{db}->{module2dist}->{$name};
+		my $failed = $self->command_module( $dists, $name, $version || '' );
 
-		if ( !$distname ) {
+		if ( $failed ) {
 			$self->verbose( "Module '$name' is not in database" );
 			next;
 		}
-
-		$dists->{$distname} = $version || '';
 	}
 
 	return;

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -195,6 +195,7 @@ sub process_options {
 		'version'         => \$params{version},
 		'exclude=s@'      => \$params{exclude},
 		'exclude-file=s@' => \$params{exclude_file},
+		'modules=s@'      => \$params{modules},
 		};
 
 	my $ret = Getopt::Long::GetOptionsFromArray( $args, $options, %$params )
@@ -228,6 +229,7 @@ cpan-audit [command] [options]
 Commands:
 
     module         [version range]    audit module with optional version range (all by default)
+    modules        [version range]    audit module list with optional version range (all by default)
     dist|release   [version range]    audit distribution with optional version range (all by default)
     deps           [directory]        audit dependencies from the directory (. by default)
     installed                         audit all installed modules
@@ -255,6 +257,8 @@ Examples:
     cpan-audit dist Catalyst-Runtime '>5.48'
 
     cpan-audit module Catalyst 7.0
+
+    cpan-audit modules "Catalyst;7.0" "Mojolicious;>8.40,<9.20"
 
     cpan-audit deps .
     cpan-audit deps /path/to/distribution

--- a/t/cli/modules.t
+++ b/t/cli/modules.t
@@ -1,0 +1,82 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use Test::More;
+use TestCommand;
+
+subtest 'command: modules' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN' );
+
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
+subtest 'command: modules with two modules' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN', 'Mojolicious;>8.40,<9.20' );
+
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    like $stdout, qr/CPANSA-Mojolicious-2022-03/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
+subtest 'command: modules, with excluded result' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN', 'Mojolicious;>8.40,<9.20','--exclude' => 'CPANSA-CPAN-2009-01', '--exclude' => 'CPANSA-Mojolicious-2022-03' );
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    unlike $stdout, qr/CPANSA-Mojolicious-2022-03/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
+subtest 'command: modules, with excluded results from file' => sub {
+    my $file = 't/data/modules_excludes';
+    ok( -e $file, 'File that should be there is there' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN', 'Mojolicious;>8.40,<9.20', '--exclude-file' => $file );
+
+    unlike $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    unlike $stdout, qr/CPANSA-Mojolicious-2022-03/;
+    is $stderr,   '';
+    isnt $exit,   0;
+};
+
+subtest 'command: modules, with excluded results from non-existent file' => sub {
+    my $file = 't/data/not-there';
+    ok( ! -e $file, 'File that should not exist is not there' );
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN', 'Mojolicious;>8.40,<9.20', '--exclude-file' => $file );
+
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+    like $stdout, qr/CPANSA-Mojolicious-2022-03/;
+
+    like $stderr, qr/unable to open exclude_file/;
+};
+
+subtest 'command: unknown modules' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'Unknown' );
+
+    like $stderr, qr/Module 'Unknown' is not in database/;
+    is $stdout,  '';
+};
+
+subtest 'command: unknown modules (mixed)' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules', 'CPAN', 'Unknown' );
+
+    like $stderr, qr/Module 'Unknown' is not in database/;
+    like $stdout, qr/CPANSA-CPAN-2009-01/;
+    like $stdout, qr/CPANSA-CPAN-2020-16156/;
+};
+
+subtest 'command: invalid invocation' => sub {
+    my ( $stdout, $stderr, $exit ) = TestCommand->command( 'modules' );
+
+    is $stdout,   '';
+    like $stderr, qr/Error: Usage: /;
+    isnt $exit,   0;
+};
+
+done_testing;

--- a/t/data/modules_excludes
+++ b/t/data/modules_excludes
@@ -1,0 +1,5 @@
+# Comments are ignored
+
+# as well as blank lines (previous line)
+    CPANSA-CPAN-2009-01   # trailing comments are removed, as is leading/trailing whitespace
+CPANSA-Mojolicious-2022-03


### PR DESCRIPTION
As discussed in #28 it should be possible to pass a list of modules to cpan-audit. This PR adds a `modules` command:

```
cpan-audit modules Foo Bar
cpan-audit modules Foo "Bar;>4.0,<4.1"
```