### PR TITLE
stability improvements to util/generate

### DIFF
--- a/util/generate
+++ b/util/generate
@@ -221,8 +221,27 @@ sub process_files ( $files ) {
     provides( \%db );
 
     foreach my $dist ( keys %{ $db{dists} } ) {
-        $db{dists}->{$dist}->{versions} = [ all_releases($dist) ];
-        $db{dists}->{$dist}->{main_module} = release($dist)->{main_module};
+        my @releases = all_releases($dist);
+        if (!@releases) {
+            warn "no releases found on CPAN for '$dist'\n";
+            next;
+        }
+        message('.');
+
+        # try to fetch the latest release, according to MetaCPAN.
+        # if there is no 'latest' tag, grab the last item (because
+        # the list is ordered by date).
+        my ($main_module, @versions);
+        foreach my $release (@releases) {
+            push @versions, { date => $release->{date}, version => $release->{version} };
+            if ($release->{status} eq 'latest') {
+                $main_module = $release->{main_module};
+            }
+        }
+        $main_module = $releases[-1]->{main_module} unless $main_module;
+
+        $db{dists}->{$dist}->{versions} = \@versions;
+        $db{dists}->{$dist}->{main_module} = $main_module;
     }
 
     # XXX: need to investigate why this shows up as utf8
@@ -307,18 +326,6 @@ sub provides {
     close $fh;
 }
 
-sub release {
-    my ($distribution) = @_;
-
-    my $response = HTTP::Tiny->new->get(
-        'http://fastapi.metacpan.org/v1/release/' . $distribution );
-
-    die "unable to retrieve data for $distribution ($response->{status})" unless $response->{success};
-    my $content_json = JSON::decode_json( $response->{content} );
-
-    return $content_json;
-}
-
 sub all_releases {
     my ($distribution) = @_;
 
@@ -329,7 +336,7 @@ sub all_releases {
             content => JSON::encode_json(
                 {
                     size   => 5000,
-                    fields => [ 'date', 'version' ],
+                    fields => [ 'date', 'version', 'status', 'main_module' ],
                     filter => {
                         term => { distribution => $distribution }
                     },

--- a/util/generate
+++ b/util/generate
@@ -214,10 +214,7 @@ sub process_files ( $files ) {
         message( "Processing $file...\n" );
         my $yaml = YAML::Tiny->read($file)->[0];
 
-        my $dist = basename $file;
-        $dist =~ s{\ACPANSA-}{};
-        $dist =~ s{\.yml\z}{};
-
+        my $dist = $yaml->[0]{distribution} or die "distribution name not found on report $file";
         $db{dists}->{$dist}->{advisories} = $yaml;
     }
 

--- a/util/generate
+++ b/util/generate
@@ -228,7 +228,7 @@ sub process_files ( $files ) {
     # XXX: need to investigate why this shows up as utf8
     $db{dists}->{'perl'}->{main_module} = 'perl';
 
-    \%db;
+    return \%db;
 }
 
 sub stringify_data ( $db ) {

--- a/util/generate
+++ b/util/generate
@@ -332,7 +332,8 @@ sub all_releases {
                     fields => [ 'date', 'version' ],
                     filter => {
                         term => { distribution => $distribution }
-                    }
+                    },
+                    sort => ['date'],
                 }
             )
         }
@@ -341,9 +342,7 @@ sub all_releases {
     die "unable to retrieve data for $distribution ($response->{status})" unless $response->{success};
     my $content_json = JSON::decode_json( $response->{content} );
 
-    my @results =
-      sort { $a->{date} cmp $b->{date} }
-      map  { $_->{fields} } @{ $content_json->{hits}->{hits} };
+    my @results = map  { $_->{fields} } @{ $content_json->{hits}->{hits} };
     return unless @results;
 
     return @results;

--- a/util/generate
+++ b/util/generate
@@ -135,7 +135,7 @@ sub get_previous_date_serial ( $file ) {
 	open my $fh, '<:encoding(UTF-8)', $file or croak( "Could not read <$file>: $!" );
 	while( <$fh> ) {
 		next unless /VERSION\s*=\s*'(\d{8})\.(\d{3})'/;
-		return ( $1, 2 );
+		return ( $1, $2 );
 	}
 	return;
 }

--- a/util/generate
+++ b/util/generate
@@ -14,6 +14,7 @@ use HTTP::Tiny;
 use JSON ();
 use PerlIO::gzip;
 use YAML::Tiny;
+use File::Temp;
 
 use subs qw(config);
 
@@ -270,7 +271,8 @@ sub provides {
 
     my $ua = HTTP::Tiny->new;
 
-    my $details_file = '/tmp/02packages.details.txt.gz';
+    my $tmpdir = File::Temp::tempdir();
+    my $details_file = File::Spec->catfile($tmpdir, '02packages.details.txt.gz');
     message( "Downloading 02packages.details.txt.gz (this may take awhile)\n" );
     $ua->mirror( 'http://www.cpan.org/modules/02packages.details.txt.gz',
         $details_file );

--- a/util/generate
+++ b/util/generate
@@ -122,7 +122,7 @@ sub default_version () {
 	my( $previous_date, $previous_serial ) = get_previous_date_serial( $opts->{output_file} );
 say STDERR "PREVIOUS DATE: $previous_date PREVIOUS SERIAL: $previous_serial";
 
-	my $serial = sprintf '%03d', $previous_date == $date ? $previous_serial + 1 : 1;
+	my $serial = sprintf '%03d', $previous_date eq $date ? $previous_serial + 1 : 1;
 say STDERR "NEW SERIAL: $serial";
 say STDERR "NEW DATE: $date";
 
@@ -137,7 +137,7 @@ sub get_previous_date_serial ( $file ) {
 		next unless /VERSION\s*=\s*'(\d{8})\.(\d{3})'/;
 		return ( $1, $2 );
 	}
-	return;
+	return ('N/A', 'N/A');
 }
 
 sub run ( @args ) {

--- a/util/generate
+++ b/util/generate
@@ -313,6 +313,7 @@ sub release {
     my $response = HTTP::Tiny->new->get(
         'http://fastapi.metacpan.org/v1/release/' . $distribution );
 
+    die "unable to retrieve data for $distribution ($response->{status})" unless $response->{success};
     my $content_json = JSON::decode_json( $response->{content} );
 
     return $content_json;
@@ -337,6 +338,7 @@ sub all_releases {
         }
     );
 
+    die "unable to retrieve data for $distribution ($response->{status})" unless $response->{success};
     my $content_json = JSON::decode_json( $response->{content} );
 
     my @results =

--- a/util/generate
+++ b/util/generate
@@ -168,6 +168,7 @@ sub run ( @args ) {
         else                       { stringify_data($db) }
     };
 
+    message("\nwriting to " . ($opts->{output_file} && $opts->{output_file} ne '-' ? $opts->{output_file} : 'STDOUT') . "\n");
     print $out_fh $string;
 
     output_gpg_signature( $string );

--- a/util/generate
+++ b/util/generate
@@ -222,7 +222,8 @@ sub process_files ( $files ) {
     foreach my $dist ( keys %{ $db{dists} } ) {
         my @releases = all_releases($dist);
         if (!@releases) {
-            warn "no releases found on CPAN for '$dist'\n";
+            warn "no releases found on CPAN for '$dist'. Removing\n";
+            delete $db{dists}{$dist};
             next;
         }
         message('.');

--- a/util/generate
+++ b/util/generate
@@ -213,8 +213,7 @@ sub process_files ( $files ) {
     foreach my $file ( $files->@* ) {
         message( "Processing $file...\n" );
         my $yaml = YAML::Tiny->read($file)->[0];
-
-        my $dist = $yaml->[0]{distribution} or die "distribution name not found on report $file";
+        my $dist = $yaml->[0]{distribution} or next;
         $db{dists}->{$dist}->{advisories} = $yaml;
     }
 

--- a/util/generate
+++ b/util/generate
@@ -50,6 +50,17 @@ util/generate - create the data for lib/CPAN/Audit/DB.pm
 This program chews through the CPAN security advisory reports and
 makes the L<CPAN::Audit::DB> module.
 
+=head1 DEPENDENCIES
+
+Aside from L<CPAN::Audit>'s dependencies, this program also
+requires you to install the following dependencies:
+
+=over 4
+
+=item * L<Mojolicious>
+
+=back
+
 =head1 AUTHOR
 
 Original author: Viacheslav Tykhanovskyi (C<vti@cpan.org>)


### PR DESCRIPTION
Hey brian!

This patch fixes some runtime warnings and other minor issues, but also fixes an outstanding issue regarding how data was being collected from MetaCPAN API. Turns out many of the CPANSA-listed distributions did not map directly to MetaCPAN's index and were causing all sorts of weird behavior.

Overall, if this patch is applied, util/generate is expected to be faster, provide extra troubleshoot information during runtime, and yield more consistent results.

Thank you!