### PR TITLE
Straight-up copy/paste `dumper` from `Mojo::Util`

### DIFF
--- a/util/generate
+++ b/util/generate
@@ -50,17 +50,6 @@ util/generate - create the data for lib/CPAN/Audit/DB.pm
 This program chews through the CPAN security advisory reports and
 makes the L<CPAN::Audit::DB> module.
 
-=head1 DEPENDENCIES
-
-Aside from L<CPAN::Audit>'s dependencies, this program also
-requires you to install the following dependencies:
-
-=over 4
-
-=item * L<Mojolicious>
-
-=back
-
 =head1 AUTHOR
 
 Original author: Viacheslav Tykhanovskyi (C<vti@cpan.org>)
@@ -76,7 +65,7 @@ See the included F<LICENSE> file for details.
 
 run(@ARGV) unless caller;
 
-use Mojo::Util qw(dumper);
+sub dumper { Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Dump }
 
 sub process_options ( @args ) {
 	state $rc = require Getopt::Long;

--- a/util/generate
+++ b/util/generate
@@ -65,10 +65,12 @@ See the included F<LICENSE> file for details.
 
 run(@ARGV) unless caller;
 
-sub dumper { Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Dump }
+sub dumper { 
+    Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Dump 
+}
 
 sub process_options ( @args ) {
-	state $rc = require Getopt::Long;
+    state $rc = require Getopt::Long;
 
     my %results = (
     	gpg_key     => $ENV{CPAN_AUDIT_GPG_KEY_FINGERPRINT},


### PR DESCRIPTION
This sub is also in `script/cpan-audit`. 

Personally I think that having two instances of copy/pasted code is fine, but 3 is too many. 

Sorry for using up the last one though.