### PR TITLE
Include queried module names with distribution reports

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -35,12 +35,14 @@ t/data/cpanfiles/cpanfile
 t/data/excludes
 t/data/installed/perl5/lib/perl5/Catalyst.pm
 t/data/modules_excludes
+t/data/queried_modules/cpanfile
 t/discover/cpanfile.t
 t/discover/cpanfile_snapshot.t
 t/excludes.t
 t/installed.t
 t/json.t
 t/lib/TestCommand.pm
+t/queried_modules.t
 t/query.t
 t/test_manifest
 t/version.t

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -54,7 +54,7 @@ sub _handle_exclude_file {
 }
 
 sub command_module {
-	my ( $self, $dists, $module, $version_range ) = @_;
+	my ( $self, $dists, $listed, $module, $version_range ) = @_;
 	return "Usage: module <module> [version-range]" unless $module;
 
 	my $distname = $self->{db}->{module2dist}->{$module};
@@ -63,13 +63,14 @@ sub command_module {
 		return "Module '$module' is not in database";
 	}
 
+	push @{ $listed->{$distname} }, $module;
 	$dists->{$distname} = $version_range // '';
 
 	return;
 }
 
 sub command_release {
-	my ( $self, $dists, $distname, $version_range ) = @_;
+	my ( $self, $dists, $listed, $distname, $version_range ) = @_;
 	return "Usage: dist|release <module> [version-range]"
 		unless $distname;
 
@@ -83,7 +84,7 @@ sub command_release {
 }
 
 sub command_show {
-	my ( $self, $dists, $advisory_id ) = @_;
+	my ( $self, $dists, $listed, $advisory_id ) = @_;
 	return "Usage: show <advisory-id>" unless $advisory_id;
 
 	my ($release) = $advisory_id =~ m/^CPANSA-(.*?)-(\d+)-(\d+)$/;
@@ -104,13 +105,13 @@ sub command_show {
 }
 
 sub command_modules {
-	my ($self, $dists, @modules) = @_;
+	my ($self, $dists, $listed, @modules) = @_;
 	return "Usage: modules '<module>[,version-range]' '<module>[,version-range]'" unless @modules;
 
 	foreach my $module ( @modules ) {
 		my ($name, $version) = split /;/, $module;
 
-		my $failed = $self->command_module( $dists, $name, $version // '' );
+		my $failed = $self->command_module( $dists, $listed, $name, $version // '' );
 
 		if ( $failed ) {
 			$self->verbose( $failed );
@@ -122,7 +123,7 @@ sub command_modules {
 }
 
 sub command_deps {
-	my ($self, $dists, $dir) = @_;
+	my ($self, $dists, $listed, $dir) = @_;
 	$dir = '.' unless defined $dir;
 
 	return "Usage: deps <dir>" unless -d $dir;
@@ -136,6 +137,8 @@ sub command_deps {
 		  || $self->{db}->{module2dist}->{ $dep->{module} };
 		next unless $dist;
 
+		push @{ $listed->{$dist} }, $dep->{module} if !$dep->{dist};
+
 		$dists->{$dist} = $dep->{version};
 	}
 
@@ -143,7 +146,7 @@ sub command_deps {
 }
 
 sub command_installed {
-	my ($self, $dists, @args) = @_;
+	my ($self, $dists, $listed, @args) = @_;
 
 	$self->verbose('Collecting all installed modules. This can take a while...');
 
@@ -193,7 +196,8 @@ sub command {
 		errors => [],
 		dists => {},
 	);
-	my $dists = $report{dists};
+	my $dists  = $report{dists};
+	my $listed = {};
 
 	if (!$self->{no_corelist}
 		&& (   $command eq 'dependencies'
@@ -213,7 +217,7 @@ sub command {
 
 	if ( exists $command_table->{$command} ) {
 		my $method = $command_table->{$command};
-		push @{ $report{errors} }, $self->$method( $dists, @args );
+		push @{ $report{errors} }, $self->$method( $dists, $listed, @args );
 		return \%report if $command eq 'show';
 	}
 	else {
@@ -236,8 +240,9 @@ sub command {
 
 			if ( @advisories ) {
 				$dists->{$distname} = {
-					advisories => \@advisories,
-					version    => $version_range,
+					advisories     => \@advisories,
+					version        => $version_range,
+					listed_modules => $listed->{$distname} || [],
 				};
 			}
 			else {

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -314,6 +314,97 @@ It is assumed that if the required version of the module is less than
 a version of a release with a known vulnerability fix, then the module
 is considered affected.
 
+=head2 JSON data
+
+If you request JSON output, the data looks like
+
+    {
+      "meta" : {
+          ... meta information ...
+      "dists": {
+        "<distribution1>": {
+          ... distribution info ...
+        }
+      }
+      "errors" : [
+        ... list of errors - if any ...
+      ]
+    }
+
+=head3 Meta information
+
+The meta data contains information about the run of C<cpan-audit>.
+
+    {
+      "args": [
+        "Mojo::File",
+        "Mojo::UserAgent",
+        "LWP::UserAgent"
+      ],
+      "cpan_audit": {
+        "version": "20230601.002"
+      },
+      "total_advisories": 19,
+      "command": "modules"
+    }
+
+These information are shown
+
+=over 4
+
+=item * cpan_audit
+
+The version of C<cpan_audit> that is used for the audit
+
+=item * command
+
+The command of C<cpan_audit> that was run
+
+=item * args
+
+Arguments for the command
+
+=item * total_advisories
+
+Number of found advisories
+
+=back
+
+=head3 Distribtion information
+
+For each distribution where at least one advisory was found, the JSON
+looks like:
+
+      "version": "Any",
+      "advisories": [
+        {
+          ... advisory data as in the audit database ...
+        },
+	... more advisories ...
+      ]
+
+The advisory data is basically the data from the database. So this depends
+on what is known for the given advisory.
+
+The distribution information contains
+
+=over 4
+
+=item * version
+
+The version (range) that is checked for advisories
+
+=item * queried_modules
+
+The modules listed in I<cpanfile> or passed to C<module> or C<modules> command
+and that belongs to the distribution.
+
+=item * advisories
+
+A list of all vulnerabilities found for the version range
+
+=back
+
 =head2 Exit values
 
 In prior versions, C<cpan-audit> exited with the number of advisories

--- a/t/data/queried_modules/cpanfile
+++ b/t/data/queried_modules/cpanfile
@@ -1,0 +1,4 @@
+requires 'Mojo::File';
+requires 'Mojo::UserAgent';
+
+requires 'Catalyst';

--- a/t/queried_modules.t
+++ b/t/queried_modules.t
@@ -1,0 +1,128 @@
+use strict;
+use warnings;
+use lib 'lib', 't/lib';
+
+use Capture::Tiny qw(capture);
+use JSON;
+
+use Test::More;
+
+my $class = "CPAN::Audit";
+
+subtest 'setup' => sub {
+	use_ok( $class ) or BAIL_OUT( "$class did not compile: $@" );
+	};
+
+subtest 'deps queried_modules' => sub {
+    my( $stdout, $stderr, $exit ) = capture {
+        system( $^X, '-Ilib', 'script/cpan-audit', '--json', 'deps', 't/data/queried_modules' );
+    	};
+
+    is $stderr, '';
+
+    my $result_hash = JSON::decode_json( $stdout );
+    isa_ok( $result_hash, ref {} );
+    isa_ok( $result_hash->{dists}, ref {} );
+    is_deeply( $result_hash->{dists}{'Catalyst-Runtime'}{queried_modules}, ['Catalyst'], "Queried 'Catalyst'" );
+
+    my %check = map { $_ => 1 } @{ $result_hash->{dists}{'Mojolicious'}{queried_modules} || [] };
+    is_deeply( \%check, { 'Mojo::File' => 1, 'Mojo::UserAgent' => 1 }, "Queried 'Mojo::File' and 'Mojo::UserAgent'" );
+	};
+
+subtest 'module queried_modules Mojolicious' => sub {
+    my( $stdout, $stderr, $exit ) = capture {
+        system( $^X, '-Ilib', 'script/cpan-audit', '--json', 'module', 'Mojo::File' );
+    	};
+
+    is $stderr, '';
+
+    my $result_hash = JSON::decode_json( $stdout );
+    isa_ok( $result_hash, ref {} );
+    isa_ok( $result_hash->{dists}, ref {} );
+    is( $result_hash->{dists}{'Catalyst-Runtime'}{queried_modules}, undef, "Did not query 'Catalyst'" );
+    is_deeply( $result_hash->{dists}{'Mojolicious'}{queried_modules}, ['Mojo::File'], "Queried 'Mojo::File'" );
+	};
+
+subtest 'module queried_modulesi Catalyst' => sub {
+    my( $stdout, $stderr, $exit ) = capture {
+        system( $^X, '-Ilib', 'script/cpan-audit', '--json', 'module', 'Catalyst' );
+    	};
+
+    is $stderr, '';
+
+    my $result_hash = JSON::decode_json( $stdout );
+    isa_ok( $result_hash, ref {} );
+    isa_ok( $result_hash->{dists}, ref {} );
+    is_deeply( $result_hash->{dists}{'Catalyst-Runtime'}{queried_modules}, ['Catalyst'], "Queried 'Catalyst'" );
+    is( $result_hash->{dists}{'Mojolicious'}{queried_modules}, undef, "Did not query 'Mojo::File' and 'Mojo::UserAgent'" );
+	};
+
+subtest 'modules queried_modules' => sub {
+    my( $stdout, $stderr, $exit ) = capture {
+        system( $^X, '-Ilib', 'script/cpan-audit', '--json', 'modules', 'Catalyst', 'Mojo::File', 'Mojo::UserAgent' );
+    	};
+
+    is $stderr, '';
+
+    my $result_hash = JSON::decode_json( $stdout );
+    isa_ok( $result_hash, ref {} );
+    isa_ok( $result_hash->{dists}, ref {} );
+    is_deeply( $result_hash->{dists}{'Catalyst-Runtime'}{queried_modules}, ['Catalyst'], "Queried 'Catalyst'" );
+
+    my %check = map { $_ => 1 } @{ $result_hash->{dists}{'Mojolicious'}{queried_modules} || [] };
+    is_deeply( \%check, { 'Mojo::File' => 1, 'Mojo::UserAgent' => 1 }, "Queried 'Mojo::File' and 'Mojo::UserAgent'" );
+	};
+
+done_testing;
+
+BEGIN {
+	use CPAN::Audit::DB;
+    no warnings 'redefine';
+
+    sub CPAN::Audit::DB::db {
+        my $db = {
+            'dists' => {
+                'Catalyst-Runtime' => {
+                    'advisories' => [
+                        {
+                            'affected_versions' => '<5.90020',
+                            'cves' => [],
+                            'description' => 'A sample advisory for a test',
+                            'distribution' => 'Catalyst-Runtime',
+                            'fixed_versions' => '>=5.90020',
+                            'id' => 'CPANSATest-Catalyst-Runtime-2013-01',
+                            'references' => [
+                            ],
+                            'reported' => '2013-01-23'
+                        },
+                    ],
+                    'main_module' => 'Catalyst::Runtime',
+                    'versions' => [
+                        {
+                            'date' => '2021-01-01T18:10:00',
+                            'version' => '5.00',
+                        },
+                        {
+                            'date' => '2022-01-01T18:10:00',
+                            'version' => '5.70',
+                        },
+                    ],
+                },
+		'Mojolicious' => {
+		    'advisories' => [
+		        id => 1,
+			fixed_versions => '>=8',
+		    ]
+		}
+            },
+            module2dist => {
+                'Catalyst'        => 'Catalyst-Runtime',
+                'Mojo::File'      => 'Mojolicious',
+                'Mojo::UserAgent' => 'Mojolicious',
+            },
+        };
+
+        return $db;
+    }
+}
+


### PR DESCRIPTION
… JSON output

One might have »requires 'LWP::UserAgent'« in the cpan file or uses »cpan-audit --json module LWP::UserAgent« and wonders why 'libwww-perl' is listed with advisories. This commit adds a 'listed_modules' key for the dist. It changes the json, it doesn't have an impact on the standard output