### PR TITLE
fix a small typo in documentation

### DIFF
--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -370,7 +370,7 @@ Number of found advisories
 
 =back
 
-=head3 Distribtion information
+=head3 Distribution information
 
 For each distribution where at least one advisory was found, the JSON
 looks like:


### PR DESCRIPTION
Just a one character patch: s/Distribtion/Distribution/ in cpan-audit script.