### PR TITLE
fix usage message for modules command

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -106,7 +106,7 @@ sub command_show {
 
 sub command_modules {
 	my ($self, $dists, $queried, @modules) = @_;
-	return "Usage: modules '<module>[,version-range]' '<module>[,version-range]'" unless @modules;
+	return "Usage: modules '<module>[;version-range]' '<module>[;version-range]'" unless @modules;
 
 	foreach my $module ( @modules ) {
 		my ($name, $version) = split /;/, $module;


### PR DESCRIPTION
The usage message used ','  as the separator between the module name and the version range. In the code ';' was used (as ',' is also the delimiter in the version range).