### PR TITLE
Use Debian-tagged versions of perl images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,14 +48,20 @@ jobs:
             os:
                 - ubuntu-22.04
             perl-version:
-                - '5.22'
-                - '5.24'
-                - '5.26'
-                - '5.28'
-                - '5.30'
-                - '5.32'
-                - '5.34'
-                - '5.36'
+                - '5.10-buster'
+                - '5.12-buster'
+                - '5.14-buster'
+                - '5.16-buster'
+                - '5.18-buster'
+                - '5.20-buster'
+                - '5.22-buster'
+                - '5.24-buster'
+                - '5.26-buster'
+                - '5.28-buster'
+                - '5.30-bullseye'
+                - '5.32-bullseye'
+                - '5.34-bullseye'
+                - '5.36-bookworm'
                 - 'latest'
         container:
             image: perl:${{ matrix.perl-version }}


### PR DESCRIPTION
Work around for https://github.com/Perl/docker-perl/issues/161

These images tagged by their Debian base version have their manifests
published in the format currently supported by Docker Hub (Manifest V 2,
schema 2.)  Old EOL docker-perl images with the version-only tag were
published in the older (and now deprecated/disabled) format and will no longer
be updated - see also https://github.com/Perl/docker-perl/issues/100