### PR TITLE
fix pull request event trigger

### DIFF
--- a/.github/workflows/gpg_signatures.yml
+++ b/.github/workflows/gpg_signatures.yml
@@ -9,7 +9,7 @@ on:
             - 'lib/CPAN/Audit/DB.pm'
             - 'briandfoy-gpg-key-selfie.jpeg'
             - '**.gpg'
-        pull_request:
+    pull_request:
 
 jobs:
     gpg:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ on:
             - 'Changes'
             - 'LICENSE'
             - 'README.pod'
-        pull_request:
+    pull_request:
 
 jobs:
     perl:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ on:
             - 'Changes'
             - 'LICENSE'
             - 'README.pod'
-        pull_request:
+    pull_request:
 
 jobs:
     perl:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ on:
             - 'Changes'
             - 'LICENSE'
             - 'README.pod'
-        pull_request:
+    pull_request:
 
 jobs:
     perl:


### PR DESCRIPTION
`pull_request` was always its own event type, never under `push`.

(Noticed while doing #58 - only AppVeyor CI was triggered on the PR.)

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows