### PR TITLE
command installed: change audited module version range

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -199,6 +199,8 @@ sub command_installed {
 		$dists->{ $dep->{dist} } = $dep->{version};
 	}
 
+	map { $_ = "==$_" } values %$dists;
+
 	return;
 }
 


### PR DESCRIPTION
When auditing installed modules with command "installed" the audited version range is `$version`. This results in false positives for modules having advisories with an affected version range `>=$version_affected` assigned where `$version < $version_affected`.

This commit changes the audited version range to `==$version`.