### PR TITLE
command installed: remove dot from @INC

### DIFF
--- a/lib/CPAN/Audit/Installed.pm
+++ b/lib/CPAN/Audit/Installed.pm
@@ -15,7 +15,7 @@ sub find {
 	my $self = shift;
 	my (@inc) = @_;
 
-	@inc = @INC unless @inc;
+	@inc = grep !/^\.$/, @INC unless @inc;
 	@inc = grep { defined && -d $_ } map { Cwd::realpath($_) } @inc;
 
 	my %seen;


### PR DESCRIPTION
Do not consider dot entry (current directory) in `@INC` when searching for installed modules during command `installed`.

"." was present in `@INC` by default before perl v5.26.0.