### PR TITLE
fix POD syntax glitch

### DIFF
--- a/lib/CPAN/Audit/Version.pm
+++ b/lib/CPAN/Audit/Version.pm
@@ -140,7 +140,7 @@ it under the same terms as Perl itself.
 
 Viacheslav Tykhanovskyi E<lt>viacheslav.t@gmail.comE<gt>
 
-=back
+=cut
 
 
 1;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
CPAN-Audit.
We thought you might be interested in it too.

    Description: fix POD syntax glitch
     POD ERRORS
           Hey! The above document had some coding errors, which are explained below:
           Around line 143:
               =back without =over
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-01-09
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcpan-audit-perl/raw/master/debian/patches/pod-syntax.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
