### PR TITLE
Fixes to changes in v20241208.001 related to pull request #62

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,9 +18,6 @@ Revision history for Perl extension CPAN-Audit
 	eventually be phased out.
 	* The `installed` command now looks only at the versions you have 
 	installed. This changes the comparison from '>=' to '=='. (#62)
-	* The default range operator is now `==` instead of `>=`. You can 
-	always specify which way you want the check to work by using an
-	explicit range operator
 	* Since these are significant changes, please report any weird
 	situations that might arise.
 

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -196,8 +196,10 @@ sub command_installed {
 		  || $self->{db}->{module2dist}->{ $dep->{module} };
 		next unless $dist;
 
-		$dists->{ $dep->{dist} } = '==' . $dep->{version};
+		$dists->{ $dep->{dist} } = $dep->{version};
 	}
+
+	$_ = "==$_" for values %$dists;
 
 	return;
 }

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -159,6 +159,7 @@ sub command_deps {
 	return "Usage: deps <dir>" unless -d $dir;
 
 	my @deps = $self->{discover}->discover($dir);
+	push @deps, { dist => 'perl', version => $] } if $self->{include_perl};
 
 	$self->verbose( sprintf 'Discovered %d dependencies', scalar(@deps) );
 

--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -244,6 +244,7 @@ sub command {
 				my $dist = $self->{db}{module2dist}{$mod} or next;
 				$dists->{$dist} = $ver if( ! defined $dists->{$dist} or version->parse($ver) > $dists->{$dist} );
 			}
+			delete $dists->{perl};
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes the misapplication of the code change proposed in #62.

In addition it also provides a fix to another issue (https://github.com/briandfoy/cpan-audit/pull/62#issuecomment-2341467590) detected along the way when discussing #62:  Option `--perl` was unconditionally turned on for commands `installed` and `deps`.