### PR TITLE
Adds the `CPANSA::DB` version into the report metadata.

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -220,7 +220,10 @@ sub command {
 		meta => {
 			command          => $command,
 			args             => [ @args ],
-			cpan_audit       => { version => $VERSION },
+			cpan_audit       => {
+				version => $VERSION,
+				db      => $CPANSA::DB::VERSION,
+			},
 			total_advisories => 0,
 		},
 		errors => [],


### PR DESCRIPTION
With `CPANSA::DB` having been split off of the core `CPAN::Audit` distribution, it is useful to have _both_ of their version numbers present in the report metadata, not just `$CPAN::Audit::VERSION`.

I have found this most helpful when generating `--json` formatted output, as my report then clearly indicates not just which version of `CPAN::Audit` was being used, but also which version of the vulnerability database.